### PR TITLE
🚀 feat : 탈퇴 기능 API 추가

### DIFF
--- a/backend/src/main/java/com/ssafy/PloMeet/api/controller/MyMeetingController.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/controller/MyMeetingController.java
@@ -19,9 +19,6 @@ import java.util.Map;
 @RequestMapping("")
 public class MyMeetingController {
 
-    @Autowired
-    UserServiceImpl userService;
-
     private final MyMeetingService myMeetingService;
 
     //모임 가입

--- a/backend/src/main/java/com/ssafy/PloMeet/api/controller/PloggingLogController.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/controller/PloggingLogController.java
@@ -15,6 +15,7 @@ import com.ssafy.PloMeet.model.entity.Weather;
 import com.ssafy.PloMeet.model.repository.PloggingRepository;
 import com.ssafy.PloMeet.model.repository.TrashcanRepository;
 import com.ssafy.PloMeet.model.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,12 +26,11 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
+@RequiredArgsConstructor
 @CrossOrigin(origins = "*", allowedHeaders = "*")
 public class PloggingLogController {
-    @Autowired
-    UserServiceImpl userService;
-    @Autowired
-    PloggingServiceImpl ploggingService;
+    private final UserServiceImpl userService;
+    private final PloggingServiceImpl ploggingService;
 
 
     @PostMapping("/ploggings")

--- a/backend/src/main/java/com/ssafy/PloMeet/api/controller/UserController.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/controller/UserController.java
@@ -49,4 +49,31 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponseBody.of(200, "변경완료"));
     }
 
+    @PutMapping("/delete/{userId}")
+    public ResponseEntity deleteUser(@PathVariable("userId") Long userId){
+        userService.deleteUser(userId);
+        return null;
+    }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/backend/src/main/java/com/ssafy/PloMeet/api/controller/UserController.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/controller/UserController.java
@@ -4,7 +4,7 @@ import com.ssafy.PloMeet.api.request.ProfileReq;
 import com.ssafy.PloMeet.api.request.UserRegisterReq;
 import com.ssafy.PloMeet.api.response.BaseResponseBody;
 import com.ssafy.PloMeet.api.response.UserRes;
-import com.ssafy.PloMeet.api.service.UserService;
+import com.ssafy.PloMeet.api.service.UserServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +19,7 @@ import java.util.NoSuchElementException;
 @RequestMapping("/user")
 public class UserController {
 
-    private final UserService userService;
+    private final UserServiceImpl userService;
 
     //회원 가입 여부 조회
     @GetMapping("/{kakaoUserId}")
@@ -49,10 +49,10 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponseBody.of(200, "변경완료"));
     }
 
-    @PutMapping("/delete/{userId}")
-    public ResponseEntity deleteUser(@PathVariable("userId") Long userId){
-        userService.deleteUser(userId);
-        return null;
+    @PutMapping("/delete")
+    public ResponseEntity deleteUser(@RequestBody UserRegisterReq userReq){
+        userService.deleteUser(userReq.getUserId());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 }
 

--- a/backend/src/main/java/com/ssafy/PloMeet/api/request/MeetingReq.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/request/MeetingReq.java
@@ -41,7 +41,6 @@ public class MeetingReq {
         this.item = item;
     }
 
-
     public Meeting toEntity() {
         return Meeting.builder()
                 .meetingImg(meetingImg)

--- a/backend/src/main/java/com/ssafy/PloMeet/api/request/UserRegisterReq.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/request/UserRegisterReq.java
@@ -17,7 +17,7 @@ public class UserRegisterReq {
 
     private String userEmail;
 
-    private Boolean idDelete;
+    private Boolean isDelete;
 
     @Builder
     public UserRegisterReq(Long kakaoUserId, String userNickName, String userProfileImg, String userName, String userEmail) {

--- a/backend/src/main/java/com/ssafy/PloMeet/api/request/UserRegisterReq.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/request/UserRegisterReq.java
@@ -2,7 +2,9 @@ package com.ssafy.PloMeet.api.request;
 
 import com.ssafy.PloMeet.model.entity.User;
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class UserRegisterReq {
 
     private Long userId;
@@ -20,15 +22,26 @@ public class UserRegisterReq {
     private Boolean isDelete;
 
     @Builder
-    public UserRegisterReq(Long kakaoUserId, String userNickName, String userProfileImg, String userName, String userEmail) {
+    public UserRegisterReq(Long userId, Long kakaoUserId, String userNickName, String userProfileImg, String userName, String userEmail, boolean isDelete) {
+        this.userId = userId;
         this.kakaoUserId = kakaoUserId;
         this.userNickName = userNickName;
         this.userProfileImg = userProfileImg;
         this.userName = userName;
         this.userEmail = userEmail;
+        this.isDelete = isDelete;
     }
 
     public User toEntity() {
+        if(userId != 0l)
+            return User.builder()
+                    .userId(userId)
+                    .kakaoUserId(kakaoUserId)
+                    .userNickName(userNickName)
+                    .userProfileImg(userProfileImg)
+                    .userName(userName)
+                    .userEmail(userEmail)
+                    .build();
         return User.builder()
                 .kakaoUserId(kakaoUserId)
                 .userNickName(userNickName)

--- a/backend/src/main/java/com/ssafy/PloMeet/api/response/PloggingLogRes.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/response/PloggingLogRes.java
@@ -28,7 +28,7 @@ public class PloggingLogRes {
         for(PloggingLog p : pl){
             result.add(PloggingLogRes.builder()
                             .plogId(p.getPlogId())
-                            .userId(p.getUser().getUserId())
+                            .userId(p.getUserId().getUserId())
                             .plogDist(p.getPlogDist())
                             .plogTime(p.getPlogTime())
                             .plogWeather(p.getPlogWeather().getDesc())

--- a/backend/src/main/java/com/ssafy/PloMeet/api/response/UserRes.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/response/UserRes.java
@@ -19,18 +19,18 @@ public class UserRes {
 
     String userEmail;
 
-    Boolean idDelete;
+    String isDelete;
 
 
     @Builder
-    public UserRes(Long userId, Long kakaoUserId, String userNickName, String userProfileImg, String userName, String userEmail, Boolean idDelete) {
+    public UserRes(Long userId, Long kakaoUserId, String userNickName, String userProfileImg, String userName, String userEmail, String isDelete) {
         this.userId = userId;
         this.kakaoUserId = kakaoUserId;
         this.userNickName = userNickName;
         this.userProfileImg = userProfileImg;
         this.userName = userName;
         this.userEmail = userEmail;
-        this.idDelete = idDelete;
+        this.isDelete = isDelete;
     }
 
     public UserRes(User user){
@@ -40,6 +40,6 @@ public class UserRes {
         this.userProfileImg = user.getUserProfileImg();
         this.userName = user.getUserName();
         this.userEmail = user.getUserEmail();
-        this.idDelete = user.getIdDelete();
+        this.isDelete = user.getIsDelete().getCode();
     }
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/api/service/ChattingServiceImpl.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/service/ChattingServiceImpl.java
@@ -45,7 +45,7 @@ public class ChattingServiceImpl implements ChattingService{
         List<ChattingMemberRes> chattingMembers = new ArrayList<>();
         for(MyMeeting myMeeting: myMeetings) {
             Long userId = myMeeting.getUserId().getUserId();
-            User user = userRepository.findByUserId(userId);
+            User user = userRepository.findByUserId(userId).get();
             ChattingMemberRes chattingMember = new ChattingMemberRes(user.getUserId(), user.getUserNickName(), user.getUserProfileImg(), myMeeting.getIsLeader());
             chattingMembers.add(chattingMember);
         }

--- a/backend/src/main/java/com/ssafy/PloMeet/api/service/PloggingServiceImpl.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/service/PloggingServiceImpl.java
@@ -35,7 +35,7 @@ public class PloggingServiceImpl implements PloggingService{
                     weather = w;
             }
             return ploggingRepo.save(PloggingLog.builder()
-                    .user(user.get()).plogDist(insertLog.getPlogDist())
+                    .userId(user.get()).plogDist(insertLog.getPlogDist())
                     .plogTime(insertLog.getPlogTime()).plogDate(insertLog.getPlogDate())
                     .plogWeather(weather).route(routeJson).build());
         }else{
@@ -46,6 +46,6 @@ public class PloggingServiceImpl implements PloggingService{
 
     @Override
     public List<PloggingLog> getPloggingLogs(Optional<User> user) throws Exception {
-        return ploggingRepo.findAllByUser(user.get());
+        return ploggingRepo.findAllByUserId(user.get());
     }
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/api/service/UserService.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/service/UserService.java
@@ -17,4 +17,5 @@ public interface UserService {
     Long signUp(UserRegisterReq userRegisterReq);
     Optional<User> getUserInfo(Long userId) throws Exception;
     void updateProfile(ProfileReq profileReq);
+    void deleteUser(Long userId);
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/api/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/service/UserServiceImpl.java
@@ -37,6 +37,10 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public Long signUp(UserRegisterReq userRegisterReq) {
         User user = userRegisterReq.toEntity();
+        if(userRegisterReq.getIsDelete()) {
+            user.updateIsDelete(IsDelete.ALIVE);
+        }
+        System.out.println("wait..");
         return userRepository.save(user).getUserId();
     }
 
@@ -54,17 +58,17 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     public void deleteUser(Long userId) {
-        User user = userRepository.findById(userId).get();
+        User user = userRepository.findByUserId(userId).get();
         user.updateIsDelete(IsDelete.DEAD);
         userRepository.save(user);
-        myBadgeRepository.deleteByUserId(userId);
+        myBadgeRepository.deleteByUserId(user);
         List<MyMeeting> outList =  myMeetingRepository.findAllByUserId(userId);
-        myMeetingRepository.deleteByUserId(userId);
+        myMeetingRepository.deleteByUserId(user);
         for(MyMeeting m : outList){
             Meeting meeting = meetingRepository.findByMeetingId(m.getMeetingId().getMeetingId()).get();
             meeting.updateCnt(meeting.getMemberCnt()-1);
             meetingRepository.save(meeting);
         }
-        ploggingRepository.deleteByUserId(userId);
+        ploggingRepository.deleteByUserId(user);
     }
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/api/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/api/service/UserServiceImpl.java
@@ -3,12 +3,17 @@ package com.ssafy.PloMeet.api.service;
 import com.ssafy.PloMeet.api.request.ProfileReq;
 import com.ssafy.PloMeet.api.request.UserRegisterReq;
 import com.ssafy.PloMeet.api.response.UserRes;
+import com.ssafy.PloMeet.model.entity.Meeting;
+import com.ssafy.PloMeet.model.entity.MyMeeting;
 import com.ssafy.PloMeet.model.entity.User;
-import com.ssafy.PloMeet.model.repository.UserRepository;
+import com.ssafy.PloMeet.model.entity.enumtype.IsDelete;
+import com.ssafy.PloMeet.model.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -17,7 +22,10 @@ import java.util.Optional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
-
+    private final MyBadgeRepository myBadgeRepository;
+    private final MyMeetingRepository myMeetingRepository;
+    private final MeetingRepository meetingRepository;
+    private final PloggingRepository ploggingRepository;
     //유저 정보 조회
     @Transactional
     public UserRes findUserByKakaoUserId(Long kakaoUserId) {
@@ -42,5 +50,21 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(profileReq.getUserId()).get();
         user.updateProfile(profileReq.getUserNickName());
         userRepository.save(user);
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId).get();
+        user.updateIsDelete(IsDelete.DEAD);
+        userRepository.save(user);
+        myBadgeRepository.deleteByUserId(userId);
+        List<MyMeeting> outList =  myMeetingRepository.findAllByUserId(userId);
+        myMeetingRepository.deleteByUserId(userId);
+        for(MyMeeting m : outList){
+            Meeting meeting = meetingRepository.findByMeetingId(m.getMeetingId().getMeetingId()).get();
+            meeting.updateCnt(meeting.getMemberCnt()-1);
+            meetingRepository.save(meeting);
+        }
+        ploggingRepository.deleteByUserId(userId);
     }
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/common/util/IsDeleteConverter.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/common/util/IsDeleteConverter.java
@@ -1,0 +1,22 @@
+package com.ssafy.PloMeet.common.util;
+
+import com.ssafy.PloMeet.model.entity.enumtype.IsDelete;
+
+import javax.persistence.AttributeConverter;
+import java.util.EnumSet;
+import java.util.NoSuchElementException;
+
+public class IsDeleteConverter implements AttributeConverter<IsDelete, String> {
+
+    @Override
+    public String convertToDatabaseColumn(IsDelete attribute) { //Entity -> DB
+        return attribute.getCode();
+    }
+
+    @Override
+    public IsDelete convertToEntityAttribute(String dbData) { //DB -> Entity
+        return EnumSet.allOf(IsDelete.class).stream()
+                .filter(e->e.getCode().equals(dbData))
+                .findAny().orElseThrow(()->new NoSuchElementException());
+    }
+}

--- a/backend/src/main/java/com/ssafy/PloMeet/common/util/RouteJsonParser.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/common/util/RouteJsonParser.java
@@ -3,11 +3,11 @@ package com.ssafy.PloMeet.common.util;
 import com.ssafy.PloMeet.model.entity.Coord;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Service
+@Component
 public class RouteJsonParser {
 
     public String getArrayToJsonString( List<Coord> routeList) {

--- a/backend/src/main/java/com/ssafy/PloMeet/model/entity/Meeting.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/entity/Meeting.java
@@ -85,4 +85,6 @@ public class Meeting {
         this.meetingDate = meetingReq.getMeetingDate();
         this.item = meetingReq.getItem();
     }
+
+    public void updateCnt(Integer memberCnt){this.memberCnt=memberCnt;}
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/entity/PloggingLog.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/entity/PloggingLog.java
@@ -15,7 +15,7 @@ public class PloggingLog {
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private long plogId;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = User.class)
     @JoinColumn(name = "userId")
     private User user;
     @Column

--- a/backend/src/main/java/com/ssafy/PloMeet/model/entity/PloggingLog.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/entity/PloggingLog.java
@@ -17,7 +17,7 @@ public class PloggingLog {
     private long plogId;
     @ManyToOne(fetch = FetchType.LAZY, targetEntity = User.class)
     @JoinColumn(name = "userId")
-    private User user;
+    private User userId;
     @Column
     private float plogDist;
     @Column(length = 11)

--- a/backend/src/main/java/com/ssafy/PloMeet/model/entity/User.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/entity/User.java
@@ -2,6 +2,8 @@ package com.ssafy.PloMeet.model.entity;
 
 import com.ssafy.PloMeet.api.request.ProfileReq;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ssafy.PloMeet.common.util.IsDeleteConverter;
+import com.ssafy.PloMeet.model.entity.enumtype.IsDelete;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -30,8 +32,8 @@ public class User {
     @Column(length = 100, columnDefinition = "varchar(100) default 'https://i.postimg.cc/G23gPzdy/profile-default.png'")
     String userProfileImg;
 
-    @Column(columnDefinition = "boolean default false")
-    Boolean idDelete;
+    @Convert(converter = IsDeleteConverter.class)
+    IsDelete isDelete;
 
     @Column(length = 10)
     String userName;
@@ -52,5 +54,5 @@ public class User {
     public void updateProfile(String userNickName) {
         this.userNickName = userNickName;
     }
-
+    public void updateIsDelete(IsDelete isDelete){this.isDelete = isDelete;}
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/entity/User.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/entity/User.java
@@ -41,15 +41,16 @@ public class User {
     @Column(length = 100, unique = true)
     String userEmail;
 
-
     @Builder
-    public User(Long kakaoUserId, String userNickName, String userProfileImg, String userName, String userEmail) {
+    public User(Long userId, Long kakaoUserId, String userNickName, String userProfileImg, String userName, String userEmail) {
+        this.userId = userId;
         this.kakaoUserId = kakaoUserId;
         this.userNickName = userNickName;
         this.userProfileImg = userProfileImg;
         this.userName = userName;
         this.userEmail = userEmail;
     }
+
 
     public void updateProfile(String userNickName) {
         this.userNickName = userNickName;

--- a/backend/src/main/java/com/ssafy/PloMeet/model/entity/enumtype/CodeValue.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/entity/enumtype/CodeValue.java
@@ -1,0 +1,6 @@
+package com.ssafy.PloMeet.model.entity.enumtype;
+
+public interface CodeValue {
+    String getCode();
+    String getValue();
+}

--- a/backend/src/main/java/com/ssafy/PloMeet/model/entity/enumtype/IsDelete.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/entity/enumtype/IsDelete.java
@@ -1,0 +1,23 @@
+package com.ssafy.PloMeet.model.entity.enumtype;
+
+public enum IsDelete implements CodeValue{
+    ALIVE("N", "유저"),
+    DEAD("Y", "탈퇴유저");
+
+    private String code;
+    private String value;
+    IsDelete(String code, String value) {
+        this.code = code;
+        this.value = value;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+}

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/MeetingRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/MeetingRepository.java
@@ -3,6 +3,8 @@ package com.ssafy.PloMeet.model.repository;
 import com.ssafy.PloMeet.model.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+import java.util.Optional;
 
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+    Optional<Meeting> findByMeetingId(Long meetingId);
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/MyBadgeRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/MyBadgeRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MyBadgeRepository extends JpaRepository<MyBadge, Long> {
     boolean existsByUserIdAndBadgeId(User user, Badge badge);
+
+    void deleteByUserId(Long userId);
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/MyBadgeRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/MyBadgeRepository.java
@@ -7,6 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MyBadgeRepository extends JpaRepository<MyBadge, Long> {
     boolean existsByUserIdAndBadgeId(User user, Badge badge);
-
-    void deleteByUserId(Long userId);
+    void deleteByUserId(User user);
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/MyMeetingRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/MyMeetingRepository.java
@@ -2,6 +2,7 @@ package com.ssafy.PloMeet.model.repository;
 
 import com.ssafy.PloMeet.model.entity.Meeting;
 import com.ssafy.PloMeet.model.entity.MyMeeting;
+import com.ssafy.PloMeet.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
@@ -25,5 +26,5 @@ public interface MyMeetingRepository extends JpaRepository<MyMeeting, Long> {
 
     public List<MyMeeting> findAllByMeetingId(Meeting meetingId);
 
-    void deleteByUserId(Long userId);
+    void deleteByUserId(User user);
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/MyMeetingRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/MyMeetingRepository.java
@@ -25,4 +25,5 @@ public interface MyMeetingRepository extends JpaRepository<MyMeeting, Long> {
 
     public List<MyMeeting> findAllByMeetingId(Meeting meetingId);
 
+    void deleteByUserId(Long userId);
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/PloggingRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/PloggingRepository.java
@@ -1,7 +1,6 @@
 package com.ssafy.PloMeet.model.repository;
 
 import com.ssafy.PloMeet.model.entity.PloggingLog;
-import com.ssafy.PloMeet.model.entity.Trashcan;
 import com.ssafy.PloMeet.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,6 +9,6 @@ import java.util.List;
 
 @Repository
 public interface PloggingRepository extends JpaRepository<PloggingLog, String> {
-    List<PloggingLog> findAllByUser (User user);
-    void deleteByUserId (Long userId);
+    List<PloggingLog> findAllByUserId (User user);
+    void deleteByUserId (User user);
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/PloggingRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/PloggingRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 @Repository
 public interface PloggingRepository extends JpaRepository<PloggingLog, String> {
     List<PloggingLog> findAllByUser (User user);
+    void deleteByUserId (Long userId);
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/UserRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/UserRepository.java
@@ -8,6 +8,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Override
     Optional<User> findById(Long id);
     Optional<User> findByKakaoUserId(Long kakaoUserId);
-
     User findByUserId(Long userId);
+
 }

--- a/backend/src/main/java/com/ssafy/PloMeet/model/repository/UserRepository.java
+++ b/backend/src/main/java/com/ssafy/PloMeet/model/repository/UserRepository.java
@@ -5,9 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    @Override
-    Optional<User> findById(Long id);
+    Optional<User> findByUserId(Long userId);
     Optional<User> findByKakaoUserId(Long kakaoUserId);
-    User findByUserId(Long userId);
+    //User findByUserId(Long userId);
 
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -32,7 +32,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.datasource.url=jdbc:mysql://plomeet-app.com:5050/plomeetDB?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.hikari.username=root
-spring.datasource.hikari.password=Soorim_chicken_205!
+spring.datasource.hikari.password=dbstnflagPals__1118*#
 
 
 # jwt

--- a/frontend/app/actions/userActions.js
+++ b/frontend/app/actions/userActions.js
@@ -1,3 +1,8 @@
+export const setIsDelete = (isDelete) => ({
+    type: "SET_ISDELETE",
+    payload: isDelete,
+});
+
 export const setUserId = (userId) => ({
     type: "SET_USERID",
     payload: userId,

--- a/frontend/app/components/auth/NicknameRegister.js
+++ b/frontend/app/components/auth/NicknameRegister.js
@@ -40,17 +40,15 @@ const NicknameRegister = () => {
   const name = useSelector(state => state.name)
   const img = useSelector(state => state.img)
   const email = useSelector(state => state.email)
+  const [canRegi, canRegiChange] = useState(false);
 
 
-  
-  // console.log(value);
   const NicknameUpdate = () => {
     dispatch(actions.setNickname(value));
     console.log("hey",nickname);
   }
   
-  
-  // kakaoHelper.getProfile();
+
   useEffect(() => { 
     KakaoLogins.getProfile().then(result => {
       dispatch(actions.setkakaoId(result.id))
@@ -60,10 +58,11 @@ const NicknameRegister = () => {
     });
   },[])
 
-  // setTimeout(() => {console.log(img)},100);
-  // setTimeout() 걸어줄것
-  
-  // setTimeout(() => {},100);
+  useEffect(() => { 
+    if(/^[a-zA-Zㄱ-힣0-9]{2,10}$/.test(value))canRegiChange(true);
+    else canRegiChange(false);
+  },[value])
+
   const Register = () => {
     axios.post('http://plomeet-app.com:8000/user', {
       kakaoUserId: kakaoId,
@@ -128,9 +127,11 @@ const NicknameRegister = () => {
             onChangeText={text => onChangeText(text)}
             value={value}>
           </TextInput>
+          <Text>사용 가능한 닉네임입니다.</Text>
         </View>
         <TouchableOpacity
           style={styles.button}
+          disabled={canRegi}
           onPress={() => Register()}>
           <View style={styles.button2}>
             <Text style={styles.title2}>회원가입</Text>

--- a/frontend/app/components/auth/NicknameRegister.js
+++ b/frontend/app/components/auth/NicknameRegister.js
@@ -35,6 +35,7 @@ const NicknameRegister = () => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
   const nickname = useSelector(state => state.nickname)
+  const isDelete = useSelector(state => state.isDelete)
   const userId = useSelector(state => state.userId)
   const kakaoId = useSelector(state => state.kakaoId)
   const name = useSelector(state => state.name)
@@ -63,14 +64,32 @@ const NicknameRegister = () => {
     else canRegiChange(false);
   },[value])
 
+  const getParam = ()=>{
+    let param = {};
+    if(isDelete){
+      param = {
+        userId: userId,
+        kakaoUserId: kakaoId,
+        userNickName: value, // 입력받은값으로 변경
+        userProfileImg: img,
+        userName: name,
+        userEmail: email,
+        isDelete: true
+      }
+    }else{
+      param = {
+        kakaoUserId: kakaoId,
+        userNickName: value, // 입력받은값으로 변경
+        userProfileImg: img,
+        userName: name,
+        userEmail: email,
+      }
+    }
+    return param;
+  }
+
   const Register = () => {
-    axios.post('http://plomeet-app.com:8000/user', {
-      kakaoUserId: kakaoId,
-      userNickName: value, // 입력받은값으로 변경
-      userProfileImg: img,
-      userName: name,
-      userEmail: email,
-    }, {
+    axios.post('http://127.0.0.1:8000/user', getParam(), {
       "Content-Type": "application/json",
     },).then(async(response) => {
       console.log(response);
@@ -127,11 +146,11 @@ const NicknameRegister = () => {
             onChangeText={text => onChangeText(text)}
             value={value}>
           </TextInput>
-          <Text>사용 가능한 닉네임입니다.</Text>
+          {canRegi ? <Text style={styles.blue}>사용 가능한 닉네임입니다.</Text> : <Text style={styles.red}>영문, 한글, 숫자로 이루어진 2~10자리만 가능합니다.</Text>}
         </View>
         <TouchableOpacity
           style={styles.button}
-          disabled={canRegi}
+          disabled={!canRegi}
           onPress={() => Register()}>
           <View style={styles.button2}>
             <Text style={styles.title2}>회원가입</Text>
@@ -200,6 +219,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: 250,
   },
+  blue: {
+    color: "blue"
+  },
+  red: {
+    color: "red"
+  }
 });
 
 const mapStateToProps = state => {

--- a/frontend/app/components/auth/SignUp.js
+++ b/frontend/app/components/auth/SignUp.js
@@ -12,7 +12,7 @@ import {
 import axios from 'axios';
 import AsyncStorage from '@react-native-community/async-storage';
 import * as KakaoLogins from '@react-native-seoul/kakao-login';
-
+import axiosInstance from "../../../utils/API";
 import LogoImage from '../../../assets/imgs/6881.png';
 import KakaoLogo from '../../../assets/imgs/kakao1.png';
 import LinearGradient from 'react-native-linear-gradient';
@@ -39,28 +39,25 @@ const SignUp = () => {
       if(res) { //토큰이있으면
         KakaoLogins.login()
           .then(result => {
-            console.log('갱신함')
             AsyncStorage.setItem('refreshToken', result.refreshToken);
+            //AsyncStorage.setItem('accessToken', result.accessToken);
             KakaoLogins.getProfile()
             .then(result => {
-              console.log('프로필받음?')
               kakaoUserId = result.id;
               console.log(`### Profile Result : ${JSON.stringify(result)}`);
-              axios.get('http://plomeet-app.com:8000/user/' + kakaoUserId)
+              axiosInstance.get(`/user/${kakaoUserId}`)
               .then((response) => {
                 console.log(response.status);
-                dispatch(actions.setNickname(response.data.userNickName));
-                dispatch(actions.setUserId(response.data.userId));
+                dispatch(actions.setkakaoId(result.id))
+                dispatch(actions.setImg(result.profileImageUrl))
+                dispatch(actions.setName(result.nickname))
+                dispatch(actions.setEmail(result.email))
                 if(response.status == 200){ //홈으로, Redux 저장
-                  dispatch(actions.setkakaoId(result.id))
-                  dispatch(actions.setImg(result.profileImageUrl))
-                  dispatch(actions.setName(result.nickname))
-                  dispatch(actions.setEmail(result.email))
+                  dispatch(actions.setNickname(response.data.userNickName));
+                  dispatch(actions.setUserId(response.data.userId));
                   navigation.replace('M');
-                }else{ // 진행시켜
-                  console.log('토큰은있지만 가입한적없어?? ->말이안됨')
-                  navigation.navigate('NicknameRegister');
-                }
+                }else  navigation.navigate('NicknameRegister');
+                
               }).catch((error) => {
                 console.log(error); 
               }); 
@@ -68,26 +65,32 @@ const SignUp = () => {
             
           })
       }else{ //토큰없으면 - 재가입유저는 이쪽 로직으로 연결
-        console.log('토큰없음')
         KakaoLogins.login()
           .then(result => {
             AsyncStorage.setItem('refreshToken', result.refreshToken);
+            //AsyncStorage.setItem('accessToken', result.accessToken);
             KakaoLogins.getProfile()
               .then(result => {
-                console.log(`### Profile Result : ${JSON.stringify(result)}`);
                   kakaoUserId = result.id;
-                  axios.get('http://plomeet-app.com:8000/user/' + kakaoUserId)
+                  console.log(kakaoUserId + ": kakaoUserId");
+                  axiosInstance.get(`/user/${kakaoUserId}`)
                   .then((response) => {
-                    dispatch(actions.setNickname(response.data.userNickName));
-                    dispatch(actions.setUserId(response.data.userId));
+                    console.log(response);
+                    dispatch(actions.setkakaoId(result.id))
+                    dispatch(actions.setImg(result.profileImageUrl))
+                    dispatch(actions.setName(result.nickname))
+                    dispatch(actions.setEmail(result.email))
                     if(response.status == 200){ //홈으로, Redux 저장
-                      dispatch(actions.setkakaoId(result.id))
-                      dispatch(actions.setImg(result.profileImageUrl))
-                      dispatch(actions.setName(result.nickname))
-                      dispatch(actions.setEmail(result.email))
-                      if(response.data.isDelete=='Y') navigation.navigate('NicknameRegister');
-                      else navigation.replace('M');
-                    }else{}
+                      dispatch(actions.setUserId(response.data.userId));
+                      if(response.data.isDelete=='Y'){
+                        dispatch(actions.setIsDelete(true))
+                        navigation.navigate('NicknameRegister');
+                      }
+                      else {
+                        dispatch(actions.setNickname(response.data.userNickName));
+                        navigation.replace('M');
+                      }
+                    }else navigation.navigate('NicknameRegister');
                   }).catch((error) => {
                     console.log(error); 
                   });
@@ -99,39 +102,6 @@ const SignUp = () => {
       }
     })
   }
- 
-
-  // function login() {
-  //   KakaoLogins.login()
-  //     .then(result => {
-  //       console.log(`### Login Result : ${JSON.stringify(result)}`);
-  //       AsyncStorage.setItem('refreshToken', result.refreshToken);
-  //       KakaoLogins.getProfile()
-  //         .then(result => {
-  //           console.log(`### Profile Result : ${JSON.stringify(result)}`);
-  //           navigation.navigate('NicknameRegister');
-  //         })
-  //         .catch(err => {
-  //           console.log(`### Profile Error : ${JSON.stringify(err)}`);
-  //         });
-  //     })
-  //     .catch(err => {
-  //       console.log(`### Login Error : ${JSON.stringify(err)}`);
-  //     });
-  // }
-
-  // function logout() {
-  //   AsyncStorage.clear();
-  //   KakaoLogins.logout()
-  //     .then(result => {
-  //       console.log(`### Logout Result : ${JSON.stringify(result)}`);
-  //     })
-  //     .catch(err => {
-  //       console.log(`### Logout Error : ${JSON.stringify(err)}`);
-  //     });
-  //     console.log('여기서걸리나?')
-  //   KakaoLogins.unlink();
-  // }
 
   BackHandler.addEventListener('hardwareBackPress', () => {
     return true;

--- a/frontend/app/components/auth/SignUp.js
+++ b/frontend/app/components/auth/SignUp.js
@@ -67,7 +67,7 @@ const SignUp = () => {
             })
             
           })
-      }else{ //토큰없으면
+      }else{ //토큰없으면 - 재가입유저는 이쪽 로직으로 연결
         console.log('토큰없음')
         KakaoLogins.login()
           .then(result => {
@@ -78,7 +78,6 @@ const SignUp = () => {
                   kakaoUserId = result.id;
                   axios.get('http://plomeet-app.com:8000/user/' + kakaoUserId)
                   .then((response) => {
-                    console.log(response.status);
                     dispatch(actions.setNickname(response.data.userNickName));
                     dispatch(actions.setUserId(response.data.userId));
                     if(response.status == 200){ //홈으로, Redux 저장
@@ -86,15 +85,12 @@ const SignUp = () => {
                       dispatch(actions.setImg(result.profileImageUrl))
                       dispatch(actions.setName(result.nickname))
                       dispatch(actions.setEmail(result.email))
-                      navigation.replace('M');
-                    }else{ // 진행시켜
-                      console.log('토큰은있지만 가입한적없어?? ->말이안됨')
-                      navigation.navigate('NicknameRegister');
-                    }
+                      if(response.data.isDelete=='Y') navigation.navigate('NicknameRegister');
+                      else navigation.replace('M');
+                    }else{}
                   }).catch((error) => {
                     console.log(error); 
                   });
-                //navigation.navigate('NicknameRegister');
               })
               .catch(err => {
                 console.log(`### Profile Error : ${JSON.stringify(err)}`);

--- a/frontend/app/components/auth/Splash.js
+++ b/frontend/app/components/auth/Splash.js
@@ -26,14 +26,13 @@ const AuthComponent = () => {
   const email = useSelector(state => state.email)
   
   useEffect(()=>{
+    AsyncStorage.removeItem('refreshToken');
     AsyncStorage.getItem('refreshToken').then( async res => {
-      console.log(res);
         if(res) {
           await KakaoLogins.getProfile().then(result => {
             kakaoUserId = result.id;
           });
-         
-          await axios.get('http://plomeet-app.com:8000/user/' + kakaoUserId)
+          await axios.get('http://127.0.0.1:8000/user/' + kakaoUserId)
           .then(async (response) => {
             // console.log(response.data.userId);
             dispatch(actions.setNickname(response.data.userNickName));
@@ -52,7 +51,6 @@ const AuthComponent = () => {
           })
           //})},2000);
         }else{
-          console.log('조기')
           //setTimeout(() => {navigation.navigate('SignUp');},1000);
           navigation.navigate('SignUp');
         }

--- a/frontend/app/components/my/preference/auth/index.js
+++ b/frontend/app/components/my/preference/auth/index.js
@@ -1,15 +1,33 @@
 import React, { Component, Node, Button } from 'react';
 import 'react-native-gesture-handler';
+import { useDispatch, useSelector } from 'react-redux';
 import { StyleSheet, Text, View } from "react-native";
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
+import AsyncStorage from '@react-native-community/async-storage';
+import axiosInstance from "../../../utils/API";
 
 const PreferenceAuth = () => {
     const navigation = useNavigation();
+    const userId = useSelector(state => state.userId);
+
+    const userDelete = () => {
+        AsyncStorage.removeItem('refreshToken');
+        
+        axiosInstance.put("/user/delete/" + userId)
+                    .then((response) => {
+                        if (response.status === 200) {
+                            console.log("delete success");
+                        } else {
+                            console.log("delete fail");
+                        }
+                    })
+                    .catch((response) => { console.log(response); });
+    }
 
     return (
         <View style={styles.container}>
-            <TouchableOpacity onPress={() => console.log('계정탈퇴')}>
+            <TouchableOpacity onPress={() => userDelete()}>
                 <View style={styles.listContainer}>
                     <Text style={styles.menuText}>계정탈퇴</Text>
                 </View>

--- a/frontend/app/components/my/preference/auth/index.js
+++ b/frontend/app/components/my/preference/auth/index.js
@@ -5,24 +5,34 @@ import { StyleSheet, Text, View } from "react-native";
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
 import AsyncStorage from '@react-native-community/async-storage';
-import axiosInstance from "../../../utils/API";
+import axiosInstance from "../../../../../utils/API";
+import * as KakaoLogins from '@react-native-seoul/kakao-login';
 
 const PreferenceAuth = () => {
     const navigation = useNavigation();
     const userId = useSelector(state => state.userId);
 
     const userDelete = () => {
-        AsyncStorage.removeItem('refreshToken');
-        
-        axiosInstance.put("/user/delete/" + userId)
+        KakaoLogins.logout().then(result => {
+            console.log("로그아웃 성공");
+            KakaoLogins.unlink()
+            .then(result => {
+                console.log("연결해제 성공");
+                axiosInstance.put("/user/delete",{userId:userId})
                     .then((response) => {
                         if (response.status === 200) {
                             console.log("delete success");
+                            
                         } else {
                             console.log("delete fail");
                         }
                     })
-                    .catch((response) => { console.log(response); });
+                    .catch((response) => { console.log("delete error because : " + response); });
+            }).catch(err => console.log(`### unLink Error : ${JSON.stringify(err)}`))
+        }).catch(err => {
+                console.log(`### logOut Error : ${JSON.stringify(err)}`);
+        }); 
+        AsyncStorage.removeItem('refreshToken');
     }
 
     return (

--- a/frontend/app/reducers/rootReducer.js
+++ b/frontend/app/reducers/rootReducer.js
@@ -10,6 +10,7 @@ const initialState = {
     ploggingPath: [],
     savedLogs: [],
     listMonth: "",
+    isDelete:false,
     userId: "",
     kakaoId: "",
     nickname: "",
@@ -50,6 +51,8 @@ const rootReducer = (state = initialState, action) => {
             return { ...state, savedLogs: action.payload }
         case "SET_LISTMONTH":
             return { ...state, listMonth: action.payload }
+        case "SET_ISDELETE":
+            return { ...state, isDelete: action.payload }
         case "SET_USERID":
             return { ...state, userId: action.payload }
         case "SET_KAKAOID":

--- a/frontend/utils/API.js
+++ b/frontend/utils/API.js
@@ -1,11 +1,17 @@
 import axios from "axios";
 
+// const axiosInstance = axios.create({
+//   baseURL: 'http://plomeet-app.com:8000',
+//   timeout: 30000,
+//   headers: {
+//     "Content-Type": "application/json",
+//   },
+// });
 const axiosInstance = axios.create({
-  baseURL: 'http://plomeet-app.com:8000',
+  baseURL: 'http://127.0.0.1:8000',
   timeout: 30000,
   headers: {
-    "Content-Type": "application/json",
+      "Content-Type": "application/json",
   },
 });
-
 export default axiosInstance;


### PR DESCRIPTION
## MR Description :page_facing_up:

### 목적

- 회원 탈퇴 및 재가입 기능

### 주요 변경사항

- [x]  탈퇴 관련 API 작성 완료
    - 탈퇴시 isDelete ‘Y’으로 업뎃
    - 내 뱃지, 내 모임, 플로깅기록에서 아이딧 값으로 지움
    - 내 모임에서 지우기전 연동 된 모임 리스트 유저수 -1 처리
- [x]  isDelete Enum 클래스로 처리
- [x]  프론트쪽 닉네임 유효성 검사처리
- [x]  탈퇴버튼 기능부여
- [x]  탈퇴 및 재가입 테스트
- [x]  재가입시 ‘N’으로 바꿔주기

### 진행중
- [ ]  닉네임 중복 처리
- [ ]  프론트 닉네임 안내문구 화면 조정
- [ ]  탈퇴 시 카카오 연동 끊기
- [ ] 서버 수동 배포

### 리뷰 요청

1. 탈퇴가 잘된다면
회원테이블 'Y' 다른 테이블 유저 데이터 삭제, 미팅테이블 cnt 올바른지
2. 카카오 연동이 잘끊어지고 탈퇴후 처음 카카온 로그인 페이지로 이동이 잘된다.

### 이슈 (없으면 삭제)

- 그러면 탈퇴후 재가입 유저와 처음 가입유저의 차이가 머가 있는지 궁금함, 유저 정보가 남는것말고는 차이가 없음